### PR TITLE
Use read_data method on tdms files for better performance

### DIFF
--- a/fixitfelix/error_handling.py
+++ b/fixitfelix/error_handling.py
@@ -185,7 +185,7 @@ def check_for_correct_repetition(
             old_channel.read_data(offset=offset+length,length=1)[0]
             for old_channel in all_channels
         ]
-        print(duplicate_front_values, duplicate_rear_values)
+        
         origin_front_values = [
             old_channel.read_data(offset=origin_offset-1,length=1)[0]
             for old_channel in all_channels

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -4,29 +4,29 @@ import fixitfelix.fix as fix
 
 
 def test_works_for_examples():
-    result = fix.calculate_chunk_indices_to_preserve(
+    result = fix.calculate_index_ranges_to_preserve(
         chunk_size=13, recurrence_size=3, len_data=55
     )
     assert len(result) == 4
-    assert result[3] == (48, 55)
+    assert result[3] == (48, 7)
 
 
 def test_works_for_edge_cases():
-    result = fix.calculate_chunk_indices_to_preserve(
+    result = fix.calculate_index_ranges_to_preserve(
         chunk_size=10, recurrence_size=5, len_data=60
     )
     assert len(result) == 4
-    assert result[3] == (45, 55)
-    result = fix.calculate_chunk_indices_to_preserve(
+    assert result[3] == (45, 10)
+    result = fix.calculate_index_ranges_to_preserve(
         chunk_size=10, recurrence_size=5, len_data=61
     )
     assert len(result) == 5
-    assert result[3] == (45, 55)
-    assert result[4] == (60, 61)
+    assert result[3] == (45, 10)
+    assert result[4] == (60, 1)
 
 
 def test_works_for_very_small_dataset():
-    result = fix.calculate_chunk_indices_to_preserve(
+    result = fix.calculate_index_ranges_to_preserve(
         chunk_size=8, recurrence_size=3, len_data=3
     )
     assert result == [(0, 3)]


### PR DESCRIPTION
This fix adresses issue  https://github.com/point8/fixitfelix/issues/1

By using .read_data() instead of .data only used channel slicves are read. This should improve the performance dramatically.
